### PR TITLE
Add failure detection in test script

### DIFF
--- a/tests/appsody_stacks/run_appsody_tests.sh
+++ b/tests/appsody_stacks/run_appsody_tests.sh
@@ -55,6 +55,11 @@ for test_file in $test_dir/*_test.yaml; do
             build_folder=$base_dir/build/appsody_stacks
             if [[ "$expected_image_registry" != null || "$expected_image_org" != null  ]]; then
                 result_file=$build_folder/index-src/$result_file_name
+                if [[ ! -f "$result_file" ]]; then
+                    echo "No result file to insert overrides: $result_file"
+                    success="false"
+                    break
+                fi
                 sed -e "s#{{EXTERNAL_URL}}#$expected_src_prefix#g" $result_file > $build_folder/index-src/temp-$result_file_name
                 result_file=$build_folder/index-src/temp-$result_file_name
             else
@@ -158,7 +163,9 @@ for test_file in $test_dir/*_test.yaml; do
             echo "Test passed: $test_input"
             succesful_tests+=($test_input)
         fi
-        mv $result_file $result_dir/$result_file_name
+        if [[ -f "$result_file" ]]; then
+            mv $result_file $result_dir/$result_file_name
+        fi
     fi
 done
 rm -rf $exec_config_dir

--- a/tests/appsody_stacks/run_appsody_tests.sh
+++ b/tests/appsody_stacks/run_appsody_tests.sh
@@ -174,4 +174,6 @@ passed_count=${#succesful_tests[@]}
 echo "RESULT: $passed_count / $test_count tests passed."
 if [[ $passed_count -ne $test_count ]]; then
     echo "Failed tests: ${failed_tests[*]}"
+    exit 99
 fi
+exit 0

--- a/tests/appsody_stacks/test_configurations/single_reference_overrides.yaml
+++ b/tests/appsody_stacks/test_configurations/single_reference_overrides.yaml
@@ -3,7 +3,7 @@ name: Single Reference test
 description: Configuration to test recreation of a single index
 version: 0.1.0
 stacks:
-  - name: single-ref-override
+  - name: single-ref-overrides
     repos:
       - url: file://{{TEST_DIR}}/repositories/nodejs-repo.yaml
 image-org: test_org


### PR DESCRIPTION
This PR updates the Appsody tests to detect a test failure where an expected result file is missing.

Once the initial purpose of detecting the failure is validated a second commit will be used to resolve the test error so the PR can be merged.