### PR TITLE
Write CRDs to assets folder

### DIFF
--- a/scripts/crd_build.sh
+++ b/scripts/crd_build.sh
@@ -74,6 +74,7 @@ then
         do
             group_name=$(yq r ${configfile} stack_groups[$group_count].name)
             mkdir -p $build_dir/$group_name
+            mkdir -p $assets_dir/$group_name
             
             echo "Creating stack CRDs for $group_name"
             
@@ -155,7 +156,7 @@ then
                     
                     if [ $generate_stack_CRD == true ]
                     then
-                        crd_file="$build_dir/$group_name/$stack_name-CRD.yaml"
+                        crd_file="$assets_dir/$group_name/$stack_name-CRD.yaml"
                         # Write stack CRD
                         cp -f $crd_template $crd_file
                         $(yq w -i $crd_file metadata.name $stack_name)

--- a/tests/devfile_stacks/run_devfile_tests.sh
+++ b/tests/devfile_stacks/run_devfile_tests.sh
@@ -50,7 +50,7 @@ for test_file in $test_dir/*_test.yaml; do
             done
 
             # Check output
-            results_dir=$base_dir/build/devfile_stacks
+            results_dir=$base_dir/assets/devfile_stacks
 
             # Result group exists
             expected_folder="$results_dir/$expected_group_name"


### PR DESCRIPTION
This PR updates the crd build and devfile test scripts to use the assets folder for the generated crds.